### PR TITLE
1. 修正拼字錯誤，導致 admin 的使用者總訂單數量無法顯示的問題。

### DIFF
--- a/BestStoreMVC/Controllers/AdminOrdersController.cs
+++ b/BestStoreMVC/Controllers/AdminOrdersController.cs
@@ -59,7 +59,7 @@ namespace BestStoreMVC.Controllers
                 return RedirectToAction("Index");
             }
 
-            ViewBag.NumsOrder = context.Orders.Where(o => o.ClientId == order.ClientId).Count();
+            ViewBag.NumOrders = context.Orders.Where(o => o.ClientId == order.ClientId).Count();
 
             return View(order);
         }


### PR DESCRIPTION
1. 修正拼字錯誤，導致 admin 的使用者總訂單數量無法顯示的問題。